### PR TITLE
PKG-15925: rebuild singlejar 9.0.0 against libprotobuf 7.35.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
+  - https://staging.continuum.io/pbp/fs/bazel-toolchain-feedstock/pr10/67d383c
   - https://staging.continuum.io/pbp/fs/protobuf-bazel-rules-feedstock/pr5/5b39280

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/pbp/fs/bazel-toolchain-feedstock/pr10/67d383c
+  - https://staging.continuum.io/pbp/fs/protobuf-bazel-rules-feedstock/pr5/5b39280

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 channels:
   - https://staging.continuum.io/pbp/fs/bazel-toolchain-feedstock/pr0/67d383c
-  - https://staging.continuum.io/pbp/fs/protobuf-bazel-rules-feedstock/pr5/5b39280

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/pbp/fs/bazel-toolchain-feedstock/pr10/67d383c
+  - https://staging.continuum.io/pbp/fs/bazel-toolchain-feedstock/pr0/67d383c
   - https://staging.continuum.io/pbp/fs/protobuf-bazel-rules-feedstock/pr5/5b39280

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     sha256: 97b647cadcb90514f4b4bd2cbbceed37d57bcda48d429edc62abcd72c03e5b40  # [build_platform == "osx-arm64"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -32,11 +32,11 @@ requirements:
     - {{ compiler('cxx') }}
     - bazel-toolchain >=0.2.0
     - openjdk
-    - libprotobuf
+    - libprotobuf 7.35.1
     - sed
   host:
-    - libabseil {{ libabseil }}
-    - libprotobuf {{ libprotobuf }}
+    - libabseil 20260526.0
+    - libprotobuf 7.35.1
     - protobuf-bazel-rules >=33.5
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - bazel-toolchain >=0.2.0
+    - bazel-toolchain >=0.5.0
     - openjdk
     - libprotobuf 7.35.1
     - sed


### PR DESCRIPTION
## Version
- `singlejar` `9.0.0` (rebuild, build `0` → `1`)

## Destination channel
- `main`

## Links
- Jira: [PKG-15925](https://anaconda.atlassian.net/browse/PKG-15925)
- PyPI: N/A
- GitHub: [bazelbuild/bazel](https://github.com/bazelbuild/bazel)

## Explanation of changes
- Rebuilds against hardcoded `libabseil` `20260526.0` and `libprotobuf` `7.35.1`.
- Stages `bazel-toolchain` 0.5.0 ([bazel-toolchain#10](https://github.com/AnacondaRecipes/bazel-toolchain-feedstock/pull/10), via `pr0` staging path) until it lands on main; requires `bazel-toolchain >=0.5.0` for the bazel 9 bootstrap.
- Uses `protobuf-bazel-rules` 35.1 from `pkgs/main` (PKG-16742).

[PKG-15925]: https://anaconda.atlassian.net/browse/PKG-15925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ